### PR TITLE
Add TripData table and DB integration

### DIFF
--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src/ src/
+CMD ["python", "-m", "src.scraper.scraper", "--kind", "trip", "--dir", "./scraper_data/trip_data"]
+

--- a/initdb/01_create_schema.sql
+++ b/initdb/01_create_schema.sql
@@ -8,3 +8,18 @@ CREATE TABLE public.stations (
   online       BOOLEAN NOT NULL,                     -- NEUE SPALTE
   geom         GEOGRAPHY(Point, 4326)
 );
+
+CREATE TABLE public.trips (
+  id            SERIAL PRIMARY KEY,
+  duration      INTEGER,
+  start_time    TIMESTAMP,
+  end_time      TIMESTAMP,
+  start_station INTEGER,
+  start_lat     DOUBLE PRECISION,
+  start_lon     DOUBLE PRECISION,
+  end_station   INTEGER,
+  end_lat       DOUBLE PRECISION,
+  end_lon       DOUBLE PRECISION,
+  bike_id       INTEGER,
+  bike_type     TEXT
+);

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,5 +1,6 @@
 from .connection import open_connection
 from .queries import nearest_stations
+from .loaders import insert_trips_from_csv, upsert_stations_from_json
 
 
 class Database:

--- a/src/db/loaders.py
+++ b/src/db/loaders.py
@@ -1,4 +1,5 @@
 import json
+import csv
 from pathlib import Path
 
 
@@ -45,6 +46,52 @@ def upsert_stations_from_json(path: Path, conn):
                     online,
                     lon,
                     lat,
+                ),
+            )
+        conn.commit()
+
+
+def insert_trips_from_csv(path: Path, conn):
+    """Insert cleaned trip CSV rows into the database."""
+
+    sql = """
+        INSERT INTO public.trips (
+            duration,
+            start_time,
+            end_time,
+            start_station,
+            start_lat,
+            start_lon,
+            end_station,
+            end_lat,
+            end_lon,
+            bike_id,
+            bike_type
+        ) VALUES (
+            %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s,
+            %s, %s
+        );
+    """
+
+    with conn.cursor() as cur, open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            cur.execute(
+                sql,
+                (
+                    int(row.get("duration", 0)),
+                    row.get("start_time"),
+                    row.get("end_time"),
+                    int(row.get("start_station", 0)),
+                    float(row.get("start_lat", 0.0)),
+                    float(row.get("start_lon", 0.0)),
+                    int(row.get("end_station", 0)),
+                    float(row.get("end_lat", 0.0)),
+                    float(row.get("end_lon", 0.0)),
+                    int(row.get("bike_id", 0)),
+                    row.get("bike_type"),
                 ),
             )
         conn.commit()

--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from src.data_processor.data_processor import clean_trip_csv, clean_station_csv
 from src.db.connection import open_connection
-from src.db.loaders import upsert_stations_from_json
+from src.db.loaders import upsert_stations_from_json, insert_trips_from_csv
 
 
 # ------------------------------------------------------------------ ENUM & CONFIG
@@ -128,7 +128,13 @@ def extract_trip_zip(dest_dir, zip_path):
 
             # run cleaner immediately
             latest_station = max(STATIC_DIR.glob("cleaned_station_data.csv"))
-            clean_trip_csv(dst_file, latest_station, TRIP_DIR)
+            cleaned = clean_trip_csv(dst_file, latest_station, TRIP_DIR)
+            if cleaned:
+                conn = open_connection()
+                try:
+                    insert_trips_from_csv(cleaned, conn)
+                finally:
+                    conn.close()
 
 
 def scrape_station(dest_dir: Path, session: requests.Session):

--- a/tests/db_loader_test.py
+++ b/tests/db_loader_test.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from src.db.loaders import upsert_stations_from_json
+from src.db.loaders import upsert_stations_from_json, insert_trips_from_csv
 
 
 def sample_geojson(tmp_path: Path) -> Path:
@@ -50,4 +50,29 @@ def test_upsert_executes_insert(tmp_path):
     sql = cur.execute.call_args_list[0][0][0]
     assert "INSERT INTO public.stations" in sql
     assert "ON CONFLICT (station_id)" in sql
+    conn.commit.assert_called_once()
+
+
+def sample_trip_csv(tmp_path: Path) -> Path:
+    data = (
+        "duration,start_time,end_time,start_station,start_lat,start_lon,"\
+        "end_station,end_lat,end_lon,bike_id,bike_type\n"
+        "5,2024-01-01 00:00:00,2024-01-01 00:05:00,1,52.0,13.0,2,52.1,13.1,100,standard\n"
+    )
+    path = tmp_path / "trips.csv"
+    path.write_text(data)
+    return path
+
+
+def test_insert_trips_executes_insert(tmp_path):
+    path = sample_trip_csv(tmp_path)
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+
+    insert_trips_from_csv(path, conn)
+
+    cur.execute.assert_called()
+    sql = cur.execute.call_args_list[0][0][0]
+    assert "INSERT INTO public.trips" in sql
     conn.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- create `public.trips` table in schema
- insert cleaned trip CSVs into database
- expose helper in `db` package
- extend loader tests for trip inserts
- add scraper container Dockerfile

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

