### PR TITLE
Fix trip import when cleaned file already exists

### DIFF
--- a/src/data_processor/data_processor.py
+++ b/src/data_processor/data_processor.py
@@ -117,7 +117,9 @@ def clean_trip_csv(
     dest_root.mkdir(parents=True, exist_ok=True)
     out = dest_root / src.with_suffix(".clean.csv").name
     if out.exists():
-        return None
+        # Skip expensive processing when the cleaned file already exists
+        # but still return the path so callers can work with the data.
+        return out
 
     # ▸ read
     trips = pd.read_csv(src, encoding=ENCODING, low_memory=False)

--- a/src/db/loaders.py
+++ b/src/db/loaders.py
@@ -78,6 +78,12 @@ def insert_trips_from_csv(path: Path, conn):
     with conn.cursor() as cur, open(path, newline="") as f:
         reader = csv.DictReader(f)
         for row in reader:
+            bike_id = row.get("bike_id")
+            try:
+                bike_id = int(bike_id)
+            except (TypeError, ValueError):
+                bike_id = None
+
             cur.execute(
                 sql,
                 (
@@ -90,7 +96,7 @@ def insert_trips_from_csv(path: Path, conn):
                     int(row.get("end_station", 0)),
                     float(row.get("end_lat", 0.0)),
                     float(row.get("end_lon", 0.0)),
-                    int(row.get("bike_id", 0)),
+                    bike_id,
                     row.get("bike_type"),
                 ),
             )

--- a/src/scraper/scraper.py
+++ b/src/scraper/scraper.py
@@ -162,10 +162,9 @@ def extract_trip_zip(dest_dir, zip_path):
                 continue
 
             dst_file = dest_dir / Path(m.filename).name
-            if dst_file.exists():
-                continue
-            with zf.open(m) as src, open(dst_file, "wb") as out:
-                shutil.copyfileobj(src, out)
+            if not dst_file.exists():
+                with zf.open(m) as src, open(dst_file, "wb") as out:
+                    shutil.copyfileobj(src, out)
 
             # run cleaner immediately if station data is available
 
@@ -178,15 +177,13 @@ def extract_trip_zip(dest_dir, zip_path):
                 )
             else:
                 try:
-                    cleaned = clean_trip_csv(dst_file, station_csv, TRIP_DIR)
+                    cleaned_path = clean_trip_csv(dst_file, station_csv, TRIP_DIR)
                 except Exception as exc:
                     print(f"Warning: failed to clean trip data {dst_file.name}: {exc}")
-                    cleaned = None
-
-                if cleaned:
+                else:
                     conn = open_connection()
                     try:
-                        insert_trips_from_csv(cleaned, conn)
+                        insert_trips_from_csv(cleaned_path, conn)
                     finally:
                         conn.close()
 

--- a/tests/db_loader_test.py
+++ b/tests/db_loader_test.py
@@ -64,6 +64,17 @@ def sample_trip_csv(tmp_path: Path) -> Path:
     return path
 
 
+def sample_trip_csv_non_numeric(tmp_path: Path) -> Path:
+    data = (
+        "duration,start_time,end_time,start_station,start_lat,start_lon,"
+        "end_station,end_lat,end_lon,bike_id,bike_type\n"
+        "5,2024-01-01 00:00:00,2024-01-01 00:05:00,1,52.0,13.0,2,52.1,13.1,15316a,standard\n"
+    )
+    path = tmp_path / "trips_bad.csv"
+    path.write_text(data)
+    return path
+
+
 def test_insert_trips_executes_insert(tmp_path):
     path = sample_trip_csv(tmp_path)
     conn = MagicMock()
@@ -76,3 +87,15 @@ def test_insert_trips_executes_insert(tmp_path):
     sql = cur.execute.call_args_list[0][0][0]
     assert "INSERT INTO public.trips" in sql
     conn.commit.assert_called_once()
+
+
+def test_insert_trips_handles_non_numeric_bike_id(tmp_path):
+    path = sample_trip_csv_non_numeric(tmp_path)
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+
+    insert_trips_from_csv(path, conn)
+
+    args = cur.execute.call_args_list[0][0][1]
+    assert args[9] is None


### PR DESCRIPTION
## Summary
- return path from `clean_trip_csv` even if cleaned file is present
- import trips whenever a cleaned CSV path is available
- don't skip cleaning step when raw file already extracted

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851a2fc09248323af5c0273140b692d