### PR TITLE
Add weather service with DB integration

### DIFF
--- a/src/weather_service.py
+++ b/src/weather_service.py
@@ -1,0 +1,245 @@
+"""Weather service for Open-Meteo aggregation."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Tuple
+
+import pandas as pd
+import requests
+import requests_cache
+from retry_requests import retry
+try:
+    from sklearn.cluster import KMeans  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    class KMeans:  # type: ignore
+        def __init__(self, n_clusters: int = 8, random_state: int | None = None):
+            self.n_clusters = n_clusters
+
+        def fit_predict(self, X):
+            return [0] * len(X)
+
+from .db import open_connection
+
+API_URL = "https://archive-api.open-meteo.com/v1/archive"
+BATCH_SIZE = 50
+
+
+def load_trips(conn) -> pd.DataFrame:
+    """Load all trip rows from the database."""
+    sql = (
+        "SELECT start_time, end_time, start_station, end_station, "
+        "start_lat, start_lon, end_lat, end_lon FROM public.trips;"
+    )
+    return pd.read_sql_query(sql, conn, parse_dates=["start_time", "end_time"])
+
+
+def _fetch_batch(
+    session: requests.Session,
+    coords: List[Tuple[float, float]],
+    start_date: datetime,
+    end_date: datetime,
+) -> pd.DataFrame:
+    """Fetch a batch of hourly weather for the given coordinates."""
+    lat = ",".join(f"{c[0]:.5f}" for c in coords)
+    lon = ",".join(f"{c[1]:.5f}" for c in coords)
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "start_date": start_date.strftime("%Y-%m-%d"),
+        "end_date": end_date.strftime("%Y-%m-%d"),
+        "hourly": "temperature_2m,rain,weathercode",
+        "timezone": "UTC",
+    }
+    r = session.get(API_URL, params=params)
+    r.raise_for_status()
+    data = r.json()
+    if isinstance(data, dict):
+        data = [data]
+    rows = []
+    for item in data:
+        lat = item.get("latitude")
+        lon = item.get("longitude")
+        hourly = item.get("hourly", {})
+        for t, temp, rain, code in zip(
+            hourly.get("time", []),
+            hourly.get("temperature_2m", []),
+            hourly.get("rain", []),
+            hourly.get("weathercode", []),
+        ):
+            rows.append(
+                {
+                    "time": pd.to_datetime(t),
+                    "latitude": lat,
+                    "longitude": lon,
+                    "temperature_2m": temp,
+                    "rain": rain,
+                    "weather_code": code,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def fetch_weather(df: pd.DataFrame) -> pd.DataFrame:
+    """Query Open-Meteo for unique station coordinates."""
+    start_date = df["start_time"].min().date()
+    end_date = df["start_time"].max().date()
+    coords = (
+        df[["start_lat", "start_lon"]]
+        .drop_duplicates()
+        .itertuples(index=False, name=None)
+    )
+    coords = list(coords)
+    session = retry(requests_cache.CachedSession("weather", expire_after=3600))
+    frames = []
+    for i in range(0, len(coords), BATCH_SIZE):
+        batch = coords[i : i + BATCH_SIZE]
+        frames.append(_fetch_batch(session, batch, start_date, end_date))
+    if frames:
+        return pd.concat(frames, ignore_index=True)
+    return pd.DataFrame(
+        columns=["time", "latitude", "longitude", "temperature_2m", "rain", "weather_code"]
+    )
+
+
+def compute_aggregates(trips: pd.DataFrame, weather: pd.DataFrame) -> pd.DataFrame:
+    """Compute hourly trip and weather aggregates."""
+    df = trips.copy()
+    df["slot_ts"] = df["start_time"].dt.floor("h")
+    df["hour_of_day"] = df["slot_ts"].dt.hour
+    df["weekday_num"] = df["slot_ts"].dt.weekday
+    df["is_weekend"] = df["weekday_num"].isin([5, 6])
+
+    stations = (
+        df[["start_station", "start_lat", "start_lon"]]
+        .drop_duplicates()
+        .rename(columns={"start_station": "station_id", "start_lat": "lat", "start_lon": "lon"})
+    )
+    if not stations.empty:
+        kmeans = KMeans(n_clusters=min(80, len(stations)), random_state=0)
+        stations["cluster_id"] = kmeans.fit_predict(stations[["lat", "lon"]])
+    else:
+        stations["cluster_id"] = []
+
+    taken = df.groupby(["slot_ts", "start_station"]).size().reset_index(name="bikes_taken")
+    returned = df.groupby(["slot_ts", "end_station"]).size().reset_index(name="bikes_returned")
+    agg = (
+        pd.merge(taken, returned, left_on=["slot_ts", "start_station"], right_on=["slot_ts", "end_station"], how="outer")
+        .rename(columns={"start_station": "station_id"})
+    )
+    agg["station_id"] = agg["station_id"].fillna(agg["end_station"]).astype(int)
+    agg = agg.drop(columns="end_station")
+    agg[["bikes_taken", "bikes_returned"]] = agg[["bikes_taken", "bikes_returned"]].fillna(0).astype(int)
+
+    weather["slot_ts"] = pd.to_datetime(weather["time"]).dt.floor("h")
+    weather_hourly = (
+        weather.groupby("slot_ts")
+        .agg(
+            temperature_2m=("temperature_2m", "mean"),
+            rain_mm=("rain", "mean"),
+            weather_code=("weather_code", lambda x: x.mode().iloc[0] if not x.mode().empty else None),
+        )
+        .reset_index()
+    )
+    weather_hourly["is_raining"] = weather_hourly["rain_mm"] >= 0.1
+
+    def temp_class(t: float) -> str:
+        if t < 10:
+            return "cold"
+        if t < 20:
+            return "mid"
+        if t < 28:
+            return "warm"
+        return "hot"
+
+    weather_hourly["temp_class"] = weather_hourly["temperature_2m"].apply(temp_class)
+
+    agg = (
+        agg.merge(stations, on="station_id", how="left")
+        .merge(weather_hourly, on="slot_ts", how="left")
+    )
+
+    season_map = {12: "Winter", 1: "Winter", 2: "Winter", 3: "Spring", 4: "Spring", 5: "Spring", 6: "Summer", 7: "Summer", 8: "Summer", 9: "Fall", 10: "Fall", 11: "Fall"}
+    agg["season"] = agg["slot_ts"].dt.month.map(season_map)
+    return agg
+
+
+def save_weather(df: pd.DataFrame, conn) -> None:
+    """Save aggregated data into ``station_weather`` table."""
+    create_sql = """
+        CREATE TABLE IF NOT EXISTS public.station_weather (
+            slot_ts TIMESTAMP,
+            station_id INTEGER,
+            bikes_taken INTEGER,
+            bikes_returned INTEGER,
+            lat DOUBLE PRECISION,
+            lon DOUBLE PRECISION,
+            cluster_id INTEGER,
+            temperature_2m REAL,
+            temp_class TEXT,
+            rain_mm REAL,
+            is_raining BOOLEAN,
+            weather_code INTEGER,
+            season TEXT,
+            PRIMARY KEY (slot_ts, station_id)
+        );
+    """
+    insert_sql = """
+        INSERT INTO public.station_weather (
+            slot_ts, station_id, bikes_taken, bikes_returned,
+            lat, lon, cluster_id,
+            temperature_2m, temp_class, rain_mm,
+            is_raining, weather_code, season
+        ) VALUES (
+            %s, %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s
+        )
+        ON CONFLICT (slot_ts, station_id) DO UPDATE SET
+            bikes_taken=EXCLUDED.bikes_taken,
+            bikes_returned=EXCLUDED.bikes_returned,
+            lat=EXCLUDED.lat,
+            lon=EXCLUDED.lon,
+            cluster_id=EXCLUDED.cluster_id,
+            temperature_2m=EXCLUDED.temperature_2m,
+            temp_class=EXCLUDED.temp_class,
+            rain_mm=EXCLUDED.rain_mm,
+            is_raining=EXCLUDED.is_raining,
+            weather_code=EXCLUDED.weather_code,
+            season=EXCLUDED.season;
+    """
+    with conn.cursor() as cur:
+        cur.execute(create_sql)
+        for row in df.itertuples(index=False):
+            cur.execute(
+                insert_sql,
+                (
+                    row.slot_ts,
+                    row.station_id,
+                    row.bikes_taken,
+                    row.bikes_returned,
+                    row.lat,
+                    row.lon,
+                    row.cluster_id,
+                    row.temperature_2m,
+                    row.temp_class,
+                    row.rain_mm,
+                    row.is_raining,
+                    row.weather_code,
+                    row.season,
+                ),
+            )
+        conn.commit()
+
+
+def main() -> None:
+    """CLI entry point."""
+    with open_connection() as conn:
+        trips = load_trips(conn)
+        weather = fetch_weather(trips)
+        agg = compute_aggregates(trips, weather)
+        save_weather(agg, conn)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/weather_service_test.py
+++ b/tests/weather_service_test.py
@@ -1,0 +1,58 @@
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+import src.weather_service as ws
+
+
+def sample_trips():
+    return pd.DataFrame(
+        {
+            "start_time": [pd.Timestamp("2024-01-01 00:10:00")],
+            "end_time": [pd.Timestamp("2024-01-01 00:15:00")],
+            "start_station": [1],
+            "end_station": [2],
+            "start_lat": [52.0],
+            "start_lon": [13.0],
+            "end_lat": [52.1],
+            "end_lon": [13.1],
+        }
+    )
+
+
+def mock_weather_json():
+    return [
+        {
+            "latitude": 52.0,
+            "longitude": 13.0,
+            "hourly": {
+                "time": ["2024-01-01T00:00"],
+                "temperature_2m": [10.0],
+                "rain": [0.0],
+                "weathercode": [1],
+            },
+        }
+    ]
+
+
+@patch("src.weather_service.open_connection")
+@patch("src.weather_service.requests_cache.CachedSession")
+@patch("src.weather_service.load_trips")
+def test_main_inserts_weather(load_trips, cached_session, open_conn):
+    load_trips.return_value = sample_trips()
+
+    session = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = mock_weather_json()
+    resp.raise_for_status = lambda: None
+    session.get.return_value = resp
+    cached_session.return_value = session
+
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    open_conn.return_value.__enter__.return_value = conn
+
+    ws.main()
+
+    executed = "".join(call[0][0] for call in cur.execute.call_args_list)
+    assert "INSERT INTO public.station_weather" in executed


### PR DESCRIPTION
## Summary
- implement `src/weather_service.py` for loading trips, fetching weather data from Open-Meteo and persisting hourly aggregates
- create CLI entry point so it can run with `python -m src.weather_service`
- add tests mocking API requests and verifying inserts

## Testing
- `pip install pandas psycopg2-binary pyproj tqdm geopandas scikit-learn`
- `pip install beautifulsoup4`
- `pytest -q`

