### PR TITLE
Add XGBoost model and runtime estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,10 +268,12 @@ export ORS_API_KEY="<dein-key>"
 
 `train_rf.py` trains a baseline Random Forest on aggregated hourly data.
 Place your preprocessed dataset `trips_for_model.csv` in the project root and
-run:
+choose which target column to predict using the `--target` option (default
+`bikes_taken`). Valid choices are `bikes_taken`, `bikes_returned` and
+`net_usage` (returns minus rentals).
 
 ```bash
-python train_rf.py
+python train_rf.py --target net_usage
 ```
 
 The script prints MAE/RMSE metrics and saves the tuned model to

--- a/README.md
+++ b/README.md
@@ -276,3 +276,21 @@ python train_rf.py
 
 The script prints MAE/RMSE metrics and saves the tuned model to
 `rf_hourly.pkl`.
+
+## Train the Gradient Boosting model
+
+`train_gb.py` uses XGBoost to forecast bike demand. Metrics are written to
+`xgb_evaluation_metrics.txt` and the trained model is saved as `xgb_model.pkl`.
+Ensure `trips_for_model.csv` is available in the project root and run:
+
+```bash
+python train_gb.py
+```
+
+To estimate how long the training will take on your machine, run
+`estimate_runtime.py` which fits the model on a small sample and extrapolates the
+runtime for the full dataset:
+
+```bash
+python estimate_runtime.py
+```

--- a/README.md
+++ b/README.md
@@ -287,9 +287,10 @@ Ensure `trips_for_model.csv` is available in the project root and run:
 python train_gb.py
 ```
 
-To estimate how long the training will take on your machine, run
-`estimate_runtime.py` which fits the model on a small sample and extrapolates the
-runtime for the full dataset:
+To get an approximate idea of the training time you can run
+`estimate_runtime.py`.  The script fits the model on a few small samples
+and performs a linear regression on the measured runtimes to estimate the
+time required for the full dataset:
 
 ```bash
 python estimate_runtime.py

--- a/estimate_runtime.py
+++ b/estimate_runtime.py
@@ -1,6 +1,14 @@
-"""Estimate training runtime for the XGBoost model on the full dataset."""
-import os, time, math
+"""Estimate training time for the XGBoost model via small samples.
+
+The script fits the model on a few fractions of the data and uses a simple
+linear regression on the measured runtimes to extrapolate the expected time for
+the entire dataset.  This is of course only an approximation; hardware load and
+I/O can influence the result.
+"""
+import os
+import time
 import pandas as pd
+import numpy as np
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.pipeline import Pipeline
@@ -9,16 +17,19 @@ from xgboost import XGBRegressor
 CSV_PATH = "trips_for_model.csv"
 TARGET_COL = "bikes_taken"
 TIMESTAMP_COL = "slot_ts"
-SAMPLE_FRAC = 0.05  # use 5% of rows to estimate runtime
+FRACTIONS = [0.02, 0.05, 0.1]  # sample fractions used for estimation
 
 CORES = os.cpu_count() or 8
 
 
 def build_pipeline(cat_cols, num_cols):
-    preproc = ColumnTransformer([
-        ("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols),
-        ("num", "passthrough", num_cols),
-    ], remainder="drop")
+    preproc = ColumnTransformer(
+        [
+            ("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols),
+            ("num", "passthrough", num_cols),
+        ],
+        remainder="drop",
+    )
     model = XGBRegressor(
         n_estimators=500,
         learning_rate=0.05,
@@ -32,35 +43,50 @@ def build_pipeline(cat_cols, num_cols):
     return Pipeline([("preproc", preproc), ("xgb", model)])
 
 
-def estimate_runtime(sample_frac=SAMPLE_FRAC):
+def estimate_runtime():
     total_rows = sum(1 for _ in open(CSV_PATH)) - 1
-    sample_rows = max(int(total_rows * sample_frac), 1000)
-    print(f"Total rows: {total_rows:,}. Using {sample_rows:,} rows for estimate...")
+    print(f"Total rows in dataset: {total_rows:,}")
 
-    df = pd.read_csv(CSV_PATH, nrows=sample_rows, low_memory=False)
-    df[TIMESTAMP_COL] = pd.to_datetime(df[TIMESTAMP_COL])
-    df["hour"] = df[TIMESTAMP_COL].dt.hour
-    df["weekday"] = df[TIMESTAMP_COL].dt.dayofweek
-    df["is_weekend"] = df["weekday"].isin([5, 6])
+    times = []
+    for frac in FRACTIONS:
+        rows = max(int(total_rows * frac), 1000)
+        print(f"\nUsing {rows:,} rows (~{frac:.0%}) …")
 
-    cat_cols = ["temp_class", "season", "hour", "weekday", "cluster_id", "is_weekend"]
-    num_cols = (
-        df.select_dtypes(include=["number", "bool"])
-          .columns.difference(cat_cols + [TARGET_COL, TIMESTAMP_COL])
-          .tolist()
+        df = pd.read_csv(CSV_PATH, nrows=rows, low_memory=False)
+        df[TIMESTAMP_COL] = pd.to_datetime(df[TIMESTAMP_COL])
+        df["hour"] = df[TIMESTAMP_COL].dt.hour
+        df["weekday"] = df[TIMESTAMP_COL].dt.dayofweek
+        df["is_weekend"] = df["weekday"].isin([5, 6])
+
+        cat_cols = ["temp_class", "season", "hour", "weekday", "cluster_id", "is_weekend"]
+        num_cols = (
+            df.select_dtypes(include=["number", "bool"])
+            .columns.difference(cat_cols + [TARGET_COL, TIMESTAMP_COL])
+            .tolist()
+        )
+
+        X = df.drop(columns=[TARGET_COL])
+        y = df[TARGET_COL]
+        pipe = build_pipeline(cat_cols, num_cols)
+
+        start = time.perf_counter()
+        pipe.fit(X, y)
+        elapsed = time.perf_counter() - start
+        times.append((rows, elapsed))
+        print(f"  took {elapsed:.1f}s")
+
+    sizes = np.array([t[0] for t in times])
+    secs = np.array([t[1] for t in times])
+    slope, intercept = np.polyfit(sizes, secs, 1)
+    est_total = slope * total_rows + intercept
+
+    print("\nRuntimes used for extrapolation:")
+    for r, t in times:
+        print(f"  {r:,} rows → {t:.1f}s")
+
+    print(
+        f"\nEstimated training time for full dataset: {est_total:.1f}s ({est_total/60:.1f} min)"
     )
-
-    X = df.drop(columns=[TARGET_COL])
-    y = df[TARGET_COL]
-    pipe = build_pipeline(cat_cols, num_cols)
-
-    start = time.perf_counter()
-    pipe.fit(X, y)
-    elapsed = time.perf_counter() - start
-    est_total = elapsed / sample_frac
-
-    print(f"Fitting on sample took {elapsed:.1f}s")
-    print(f"Estimated runtime for full dataset: {est_total:.1f}s ({est_total/60:.1f} min)")
 
 
 if __name__ == "__main__":

--- a/estimate_runtime.py
+++ b/estimate_runtime.py
@@ -1,0 +1,67 @@
+"""Estimate training runtime for the XGBoost model on the full dataset."""
+import os, time, math
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder
+from sklearn.pipeline import Pipeline
+from xgboost import XGBRegressor
+
+CSV_PATH = "trips_for_model.csv"
+TARGET_COL = "bikes_taken"
+TIMESTAMP_COL = "slot_ts"
+SAMPLE_FRAC = 0.05  # use 5% of rows to estimate runtime
+
+CORES = os.cpu_count() or 8
+
+
+def build_pipeline(cat_cols, num_cols):
+    preproc = ColumnTransformer([
+        ("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols),
+        ("num", "passthrough", num_cols),
+    ], remainder="drop")
+    model = XGBRegressor(
+        n_estimators=500,
+        learning_rate=0.05,
+        max_depth=8,
+        subsample=0.8,
+        colsample_bytree=0.8,
+        tree_method="hist",
+        n_jobs=CORES,
+        random_state=42,
+    )
+    return Pipeline([("preproc", preproc), ("xgb", model)])
+
+
+def estimate_runtime(sample_frac=SAMPLE_FRAC):
+    total_rows = sum(1 for _ in open(CSV_PATH)) - 1
+    sample_rows = max(int(total_rows * sample_frac), 1000)
+    print(f"Total rows: {total_rows:,}. Using {sample_rows:,} rows for estimate...")
+
+    df = pd.read_csv(CSV_PATH, nrows=sample_rows, low_memory=False)
+    df[TIMESTAMP_COL] = pd.to_datetime(df[TIMESTAMP_COL])
+    df["hour"] = df[TIMESTAMP_COL].dt.hour
+    df["weekday"] = df[TIMESTAMP_COL].dt.dayofweek
+    df["is_weekend"] = df["weekday"].isin([5, 6])
+
+    cat_cols = ["temp_class", "season", "hour", "weekday", "cluster_id", "is_weekend"]
+    num_cols = (
+        df.select_dtypes(include=["number", "bool"])
+          .columns.difference(cat_cols + [TARGET_COL, TIMESTAMP_COL])
+          .tolist()
+    )
+
+    X = df.drop(columns=[TARGET_COL])
+    y = df[TARGET_COL]
+    pipe = build_pipeline(cat_cols, num_cols)
+
+    start = time.perf_counter()
+    pipe.fit(X, y)
+    elapsed = time.perf_counter() - start
+    est_total = elapsed / sample_frac
+
+    print(f"Fitting on sample took {elapsed:.1f}s")
+    print(f"Estimated runtime for full dataset: {est_total:.1f}s ({est_total/60:.1f} min)")
+
+
+if __name__ == "__main__":
+    estimate_runtime()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ rtree
 psycopg2-binary
 
 python-dotenv
+xgboost

--- a/train_gb.py
+++ b/train_gb.py
@@ -1,0 +1,99 @@
+"""Train Gradient Boosting model (XGBoost) for bike demand forecasting."""
+import os, time, math
+import pandas as pd
+import numpy as np
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder
+from sklearn.pipeline import Pipeline
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from joblib import dump
+from xgboost import XGBRegressor
+
+CSV_PATH = "trips_for_model.csv"
+TARGET_COL = "bikes_taken"
+TIMESTAMP_COL = "slot_ts"
+CORES = os.cpu_count() or 8
+
+# 1. load data
+if not os.path.exists(CSV_PATH):
+    raise FileNotFoundError(CSV_PATH)
+
+df = pd.read_csv(CSV_PATH, low_memory=False)
+if TIMESTAMP_COL not in df.columns:
+    raise KeyError(f"Column '{TIMESTAMP_COL}' not found")
+
+df[TIMESTAMP_COL] = pd.to_datetime(df[TIMESTAMP_COL])
+
+# 2. feature engineering
+
+df["hour"] = df[TIMESTAMP_COL].dt.hour
+df["weekday"] = df[TIMESTAMP_COL].dt.dayofweek
+df["is_weekend"] = df["weekday"].isin([5, 6])
+
+cat_cols = ["temp_class","season","hour","weekday","cluster_id","is_weekend"]
+num_cols = (
+    df.select_dtypes(include=["number","bool"])
+      .columns.difference(cat_cols + [TARGET_COL, TIMESTAMP_COL])
+      .tolist()
+)
+
+preproc = ColumnTransformer([
+    ("cat", OneHotEncoder(handle_unknown="ignore"), cat_cols),
+    ("num", "passthrough", num_cols),
+], remainder="drop")
+
+# 3. split train/val/test (time-based)
+
+df = df.sort_values(TIMESTAMP_COL)
+n = len(df)
+train_end = math.floor(n * 0.70)
+val_end = math.floor(n * 0.85)
+train = df.iloc[:train_end]
+val = df.iloc[train_end:val_end]
+test = df.iloc[val_end:]
+
+X_train, y_train = train.drop(columns=[TARGET_COL]), train[TARGET_COL]
+X_val,   y_val   = val.drop(columns=[TARGET_COL]),   val[TARGET_COL]
+X_test,  y_test  = test.drop(columns=[TARGET_COL]),  test[TARGET_COL]
+
+# 4. build model
+
+xgb_params = dict(
+    n_estimators=500,
+    learning_rate=0.05,
+    max_depth=8,
+    subsample=0.8,
+    colsample_bytree=0.8,
+    tree_method="hist",
+    n_jobs=CORES,
+    random_state=42,
+)
+
+model = Pipeline([
+    ("preproc", preproc),
+    ("xgb", XGBRegressor(**xgb_params)),
+])
+
+# 5. train
+print("\u23F3 Training XGBoost …")
+t0 = time.perf_counter()
+model.fit(pd.concat([X_train, X_val]), pd.concat([y_train, y_val]))
+train_time = time.perf_counter() - t0
+print(f"Training finished in {train_time:.1f}s")
+
+# 6. evaluate
+
+y_pred = model.predict(X_test)
+metrics = {
+    "Test MAE": mean_absolute_error(y_test, y_pred),
+    "Test RMSE": np.sqrt(mean_squared_error(y_test, y_pred)),
+    "Test R2": r2_score(y_test, y_pred),
+}
+
+with open("xgb_evaluation_metrics.txt", "w") as f:
+    for m, v in metrics.items():
+        f.write(f"{m}: {v:.3f}\n")
+print("Metrics saved to xgb_evaluation_metrics.txt")
+
+dump(model, "xgb_model.pkl")
+print("Model saved to xgb_model.pkl")

--- a/train_rf.py
+++ b/train_rf.py
@@ -12,6 +12,7 @@ pip install -U scikit-learn pandas numpy joblib
 
 # ---------- imports & env -----------------------------------------------
 import os, time, math
+import argparse
 import pandas as pd
 import numpy as np
 from sklearn.compose import ColumnTransformer
@@ -27,9 +28,18 @@ from sklearn.model_selection import (
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from joblib import dump, parallel_backend
 
+parser = argparse.ArgumentParser(description="Train RandomForest demand model")
+parser.add_argument(
+    "--target",
+    choices=["bikes_taken", "bikes_returned", "net_usage"],
+    default="bikes_taken",
+    help="target column to predict",
+)
+args = parser.parse_args()
+
 # ---------- config -------------------------------------------------------
 CSV_PATH      = "trips_for_model.csv"
-TARGET_COL    = "bikes_taken"
+TARGET_COL    = args.target
 TIMESTAMP_COL = "slot_ts"
 CORES         = os.cpu_count() or 8       # M4 Pro shows 12–14
 
@@ -41,6 +51,13 @@ df = pd.read_csv(CSV_PATH, low_memory=False)
 if TIMESTAMP_COL not in df.columns:
     raise KeyError(f"Column “{TIMESTAMP_COL}” not found.")
 df[TIMESTAMP_COL] = pd.to_datetime(df[TIMESTAMP_COL])
+
+# create net_usage if possible
+if {"bikes_taken", "bikes_returned"}.issubset(df.columns):
+    df["net_usage"] = df["bikes_returned"] - df["bikes_taken"]
+
+if TARGET_COL not in df.columns:
+    raise KeyError(f"Target column '{TARGET_COL}' not found.")
 
 # ---------- 2. feature engineering --------------------------------------
 df["hour"]       = df[TIMESTAMP_COL].dt.hour


### PR DESCRIPTION
## Summary
- add `train_gb.py` for gradient boosting using XGBoost
- save evaluation metrics for the gradient boosting model
- add `estimate_runtime.py` to approximate training runtime
- document new training script and runtime estimator in README
- include `xgboost` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68590d4ce2948323a8297a377623b1f6