### PR TITLE
Add travel-time estimation and fastest route option

### DIFF
--- a/presentation/pages/1_Search_Available_Devices_Station.py
+++ b/presentation/pages/1_Search_Available_Devices_Station.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path so absolute imports work
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
 from presentation.common import station_search_page
 from usecases.stations import find_nearest_stations
 

--- a/presentation/pages/2_search_available_docking_station.py
+++ b/presentation/pages/2_search_available_docking_station.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path so absolute imports work
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
 from presentation.common import station_search_page
 from usecases.stations import find_nearest_docks
 

--- a/presentation/pages/4_nearest_stations_map.py
+++ b/presentation/pages/4_nearest_stations_map.py
@@ -1,3 +1,11 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the import path so absolute imports work
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.append(str(_REPO_ROOT))
+
 from presentation.common import REPO_ROOT
 import streamlit as st
 import pandas as pd

--- a/presentation/pages/5_route_planner.py
+++ b/presentation/pages/5_route_planner.py
@@ -104,12 +104,12 @@ if st.session_state.get("step") == 1:
     origin_choice = sc1.selectbox("Start station", list(origin_sel.keys()))
     dest_choice = sc2.selectbox("Destination station", list(dest_sel.keys()))
 
-    if st.button("Calculate route 🚀"):
+    if st.button("Calculate route 🚀", key="calc_route"):
         st.session_state["origin_station"] = origin_sel[origin_choice]
         st.session_state["dest_station"] = dest_sel[dest_choice]
         st.session_state["step"] = 2
 
-    if st.button("Suggest fastest option"):
+    if st.button("Suggest fastest option", key="fastest_option"):
         client = _get_ors_client(api_key)
         with st.spinner("Searching fastest route..."):
             best_dur = float("inf")

--- a/presentation/pages/5_route_planner.py
+++ b/presentation/pages/5_route_planner.py
@@ -17,11 +17,13 @@ def _get_ors_client(api_key: str) -> ors.Client:
 
 def _make_route(
     client: ors.Client, coords: list[list[float]], profile: str
-) -> list[list[float]]:
-    """Call ORS directions and return decoded lat/lon pairs."""
+) -> tuple[list[list[float]], float]:
+    """Return decoded lat/lon pairs and duration in minutes."""
     data = client.directions(coords, profile=profile, format="geojson")
     geometry = data["features"][0]["geometry"]["coordinates"]  # lon/lat pairs
-    return [[lat, lon] for lon, lat in geometry]
+    duration_s = data["features"][0]["properties"]["summary"]["duration"]
+    points = [[lat, lon] for lon, lat in geometry]
+    return points, duration_s / 60  # minutes
 
 
 def _add_route(map_: folium.Map, points: list[list[float]], tooltip: str, color: str):
@@ -107,6 +109,45 @@ if st.session_state.get("step") == 1:
         st.session_state["dest_station"] = dest_sel[dest_choice]
         st.session_state["step"] = 2
 
+    if st.button("Suggest fastest option"):
+        client = _get_ors_client(api_key)
+        with st.spinner("Searching fastest route..."):
+            best_dur = float("inf")
+            best_o = None
+            best_d = None
+            for o in origin_sel.values():
+                for d in dest_sel.values():
+                    try:
+                        _, t1 = _make_route(
+                            client,
+                            [[start_lon, start_lat], [o["longitude"], o["latitude"]]],
+                            profile="foot-walking",
+                        )
+                        _, t2 = _make_route(
+                            client,
+                            [[o["longitude"], o["latitude"]], [d["longitude"], d["latitude"]]],
+                            profile="cycling-regular",
+                        )
+                        _, t3 = _make_route(
+                            client,
+                            [[d["longitude"], d["latitude"]], [dest_lon, dest_lat]],
+                            profile="foot-walking",
+                        )
+                        dur = t1 + t2 + t3
+                        if dur < best_dur:
+                            best_dur = dur
+                            best_o = o
+                            best_d = d
+                    except Exception:
+                        continue
+        if best_o and best_d:
+            st.session_state["origin_station"] = best_o
+            st.session_state["dest_station"] = best_d
+            st.session_state["step"] = 2
+            st.success(
+                f"Fastest option selected: {best_o['name']} → {best_d['name']} (≈{best_dur:.1f} min)"
+            )
+
 if st.session_state.get("step") == 2:
     st.subheader("2️⃣ Optimal route")
 
@@ -124,21 +165,22 @@ if st.session_state.get("step") == 2:
     ]
 
     try:
-        walk1 = _make_route(
+        walk1, dur1 = _make_route(
             client,
             [[user_start[1], user_start[0]], [s_station[1], s_station[0]]],
             profile="foot-walking",
         )
-        bike = _make_route(
+        bike, dur2 = _make_route(
             client,
             [[s_station[1], s_station[0]], [d_station[1], d_station[0]]],
             profile="cycling-regular",
         )
-        walk2 = _make_route(
+        walk2, dur3 = _make_route(
             client,
             [[d_station[1], d_station[0]], [user_dest[1], user_dest[0]]],
             profile="foot-walking",
         )
+        total_duration = dur1 + dur2 + dur3
     except Exception as exc:
         st.error(f"OpenRouteService request failed: {exc}")
         st.stop()
@@ -170,5 +212,6 @@ if st.session_state.get("step") == 2:
     with st.expander("Details"):
         st.markdown(
             f"* **Start station:** {st.session_state['origin_station']['name']} «{st.session_state['origin_station']['distance_m']:.0f} m»\n"
-            f"* **Destination station:** {st.session_state['dest_station']['name']} «{st.session_state['dest_station']['distance_m']:.0f} m»"
+            f"* **Destination station:** {st.session_state['dest_station']['name']} «{st.session_state['dest_station']['distance_m']:.0f} m»\n"
+            f"* **Estimated travel time:** {total_duration:.1f} min"
         )

--- a/presentation/pages/5_route_planner.py
+++ b/presentation/pages/5_route_planner.py
@@ -5,6 +5,9 @@ from dotenv import load_dotenv
 from streamlit_folium import st_folium
 import openrouteservice as ors
 
+# Ensure the repository root is on the import path so absolute imports work
+from presentation.common import REPO_ROOT  # noqa: F401
+
 from infrastructure.db import DBStationRepository
 from usecases.stations import find_nearest_stations, find_nearest_docks
 

--- a/presentation/pages/5_route_planner.py
+++ b/presentation/pages/5_route_planner.py
@@ -1,4 +1,7 @@
 import os
+import sys
+from pathlib import Path
+
 import streamlit as st
 import folium
 from dotenv import load_dotenv
@@ -6,7 +9,9 @@ from streamlit_folium import st_folium
 import openrouteservice as ors
 
 # Ensure the repository root is on the import path so absolute imports work
-from presentation.common import REPO_ROOT  # noqa: F401
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.append(str(_REPO_ROOT))
 
 from infrastructure.db import DBStationRepository
 from usecases.stations import find_nearest_stations, find_nearest_docks


### PR DESCRIPTION
## Summary
- show ORS duration when building a route
- display estimated travel time in the route details
- add button to pick the fastest nearby station pair

## Testing
- `pytest -q` *
