### PR TITLE
Fix scraper Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # 4. Copy source code
 COPY src/ src/
+COPY infrastructure/ infrastructure/
+COPY domain/ domain/
 
 EXPOSE 8501
 

--- a/Dockerfile.crawler
+++ b/Dockerfile.crawler
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY src/ src/
+COPY infrastructure/ infrastructure/
+COPY domain/ domain/
 CMD ["python", "-m", "src.scraper.scraper", "--kind", "trip", "--dir", "./scraper_data/trip_data"]
 


### PR DESCRIPTION
## Summary
- copy missing directories so Docker builds can find infrastructure modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

